### PR TITLE
Replace cd.yml, pin kubernetes_helper to v1.25.0, add dependabot, update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # github-actions only: this repository holds workflows and documentation, with no
+  # Gemfile or package.json for bundler or npm to look at.
+  #
+  # Worth reviewing these more carefully than in an application repository. The
+  # workflows here run inside every application's deployment, so an action bumped in
+  # this pull request changes how all of them build and deploy on their next run. The
+  # grouping keeps that as one reviewable change per week instead of a handful of
+  # separate ones, since dependabot bumps every occurrence of an action together
+  # anyway.
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       # common steps
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.DEPLOY_BRANCH }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,45 @@
+# The current deployment pipeline. This file used to hold an older one that installed
+# kubernetes_helper from rubygems, ran on ubuntu-latest, pushed images to GCR and took no
+# inputs; nothing referenced it any more, so it has been replaced with the contents of
+# cd_new.yml rather than left to rot as a second, divergent pipeline.
+#
+# Note for anything still pointing at the old file: this now takes seven required inputs
+# (APP_NAME, GAR_BETA_REGION, GAR_PROD_REGION, GCP_STAGING_PROJECT_ID, GCP_PROD_PROJECT_ID,
+# GAR_STAGING_REPO, GAR_PRODUCTION_REPO). A reusable workflow called without a required
+# input fails before it starts a single job, so a caller has to pass all seven.
+#
+# cd_new.yml is identical and kept only so its existing callers keep working. Move them
+# here and delete it.
 name: "Continuous Deployment"
 on:
   # Make workflow reusable
   workflow_call:
     inputs:
+      APP_NAME:
+        type: string
+        required: true
+      GAR_BETA_REGION:
+        type: string
+        required: true
+      GAR_PROD_REGION:
+        type: string
+        required: true
+      GCP_STAGING_PROJECT_ID:
+        type: string
+        required: true
+      GCP_PROD_PROJECT_ID:
+        type: string
+        required: true
+      GAR_STAGING_REPO:
+        type: string
+        required: true
+      GAR_PRODUCTION_REPO:
+        type: string
+        required: true
+      DOCKER_BUILD_TARGET:
+        type: string
+        required: false
+        default: 'production'
       debug:
         type: boolean
         required: false
@@ -19,7 +56,7 @@ on:
 
 jobs:
   deployment:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     env:
@@ -27,28 +64,30 @@ jobs:
       STAGING_DEPLOY: ${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_env != 'production') }}
       STAGING_DEPLOY_ENV: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_env || 'beta'}}
       DEPLOY_BRANCH: ${{github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref}}
+
     steps:
       # common steps
-      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.DEPLOY_BRANCH }}
-      - name: Cancel previous Workflow Actions
-        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: Cancel Previous Workflow Actions
+        uses: styfle/cancel-workflow-action@0.12.0
         with:
           access_token: ${{ github.token }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         if: inputs.service == 'gcloud'
 
-      # uses: satackey/action-docker-layer-caching@v0.0.11 (outdated for deprecations)
-      - uses: jpribyl/action-docker-layer-caching@v0.1.0
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: CD-docker-cache-${{ hashFiles('Dockerfile') }}
           restore-keys: app-cache-
 
-      - name: Calc current version
+      - name: Calculate current version
         run: |
           git_hash=$(git rev-parse --verify HEAD || :)
           default_version=${git_hash:-$(date +%s)}
@@ -56,14 +95,53 @@ jobs:
           deploy_version=${deploy_version:-$default_version}
           echo "DEPLOY_VERSION=$deploy_version" >> $GITHUB_ENV
 
-      - run: "sudo gem install kubernetes_helper"
-      - name: Staging deployment
-        env: # Env variable saved in github that contains gcloud credential (json format)
+      - name: Install Specific Install gem
+        run: sudo gem install specific_install
+
+      - name: Install Kubernetes Helper with Specific Install
+        # Pinned, and named under the organisation's current name. Unpinned, this installed
+        # whatever the default branch happened to hold at the moment of the deployment, so
+        # merging anything into that gem changed every application's next deploy with no
+        # release, review or rollback in between. -t takes a git tag.
+        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.25.0
+
+      # Staging deployment
+
+      - name: Push Docker Image to GAR (Staging)
+        uses: a94763075/push-to-gar-github-action@v0.3.3
+        with:
+          gcloud_service_key: ${{ secrets.BETA_GOOGLE_AUTH }}
+          project_id: ${{ inputs.GCP_STAGING_PROJECT_ID }}
+          registry: ${{ inputs.GAR_BETA_REGION }}
+          repository: ${{ inputs.GAR_STAGING_REPO }}
+          image_name: ${{ inputs.APP_NAME }}-staging
+          image_tags: ${{ github.sha }}
+          dockerfile: './Dockerfile'
+          target: ${{ inputs.DOCKER_BUILD_TARGET }}
+        if: ${{ env.STAGING_DEPLOY == 'true' }}
+
+      - name: Staging Deployment
+        env:
           KB_AUTH_TOKEN: ${{ secrets.BETA_GOOGLE_AUTH }}
           DEPLOY_ENV: ${{ env.STAGING_DEPLOY_ENV }}
           DEPLOY_VERSION: ${{ env.DEPLOY_VERSION }}
         run: kubernetes_helper run_deployment 'cd.sh'
         if: ${{ env.STAGING_DEPLOY == 'true' }}
+
+      # Production deployment
+
+      - name: Push Docker Image to GAR (Production)
+        uses: a94763075/push-to-gar-github-action@v0.3.3
+        with:
+          gcloud_service_key: ${{ secrets.PROD_GOOGLE_AUTH }}
+          project_id: ${{ inputs.GCP_PROD_PROJECT_ID }}
+          registry: ${{ inputs.GAR_PROD_REGION }}
+          repository: ${{ inputs.GAR_PRODUCTION_REPO }}
+          image_name: ${{ inputs.APP_NAME }}-production
+          image_tags: ${{ github.sha }}
+          dockerfile: './Dockerfile'
+          target: ${{ inputs.DOCKER_BUILD_TARGET }}
+        if: ${{ env.PROD_DEPLOY == 'true' }}
 
       - name: Production deployment
         env:

--- a/.github/workflows/cd_new.yml
+++ b/.github/workflows/cd_new.yml
@@ -1,3 +1,6 @@
+# Kept for its existing callers only. cd.yml is identical and is the canonical copy;
+# point callers there and delete this file. Any change made here has to be made there too
+# until that happens.
 name: "Continuous Deployment"
 on:
   # Make workflow reusable
@@ -87,7 +90,11 @@ jobs:
         run: sudo gem install specific_install
 
       - name: Install Kubernetes Helper with Specific Install
-        run: sudo gem specific_install -l https://github.com/ReverseRetail/kubernetes_helper
+        # Pinned, and named under the organisation's current name. Unpinned, this installed
+        # whatever the default branch happened to hold at the moment of the deployment, so
+        # merging anything into that gem changed every application's next deploy with no
+        # release, review or rollback in between. -t takes a git tag.
+        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.25.0
 
       # Staging deployment
 

--- a/.github/workflows/cd_new.yml
+++ b/.github/workflows/cd_new.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       # common steps
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.DEPLOY_BRANCH }}
 

--- a/.github/workflows/release_builder.yml
+++ b/.github/workflows/release_builder.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_builder_from_tag.yml
+++ b/.github/workflows/release_builder_from_tag.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       # common steps
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Copy env vars file
         run: cp .env-example .env
         if: inputs.copy_env
@@ -69,7 +69,7 @@ jobs:
         run: cp config/database-example.yml config/database.yml
         if: inputs.copy_db_yml
       - name: Cancel previous Workflow Actions
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.12.0
         with:
           access_token: ${{ github.token }}
 
@@ -90,7 +90,7 @@ jobs:
         run: docker-compose pull
 
       # uses: satackey/action-docker-layer-caching@v0.0.11 (outdated for deprecations)
-      - uses: jpribyl/action-docker-layer-caching@v0.1.0
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true # Ignore the failure of a step and avoid terminating the job.
         with:
           key: app-cache-${{ hashFiles('Dockerfile') }}
@@ -125,7 +125,7 @@ jobs:
         if: inputs.eslint_cmd != ''
 
       - name: Upload final coverage results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v7
         with:
           name: final-coverage-report
           path: coverage
@@ -154,7 +154,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: inputs.debug && always()
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: capybara-screenshots
           path: tmp/capybara


### PR DESCRIPTION
Three commits.

> ⚠️ **This repository's `tests.yml` is what storage_service's "App tests" runs through.** Commit 3 bumps actions inside it, so storage_service's CI exercises those bumps the moment this merges. [storage_service#361](https://github.com/BuddyandSelly/storage_service/pull/361) is green right now — worth re-checking it after.

### `eaa5247` — replace `cd.yml`, and pin the gem

```diff
-        run: sudo gem specific_install -l https://github.com/ReverseRetail/kubernetes_helper
+        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.25.0
```

Unpinned, `specific_install` takes the repository's **default branch**. So merging anything into that gem changed every application's next deployment, with no release, review or rollback in between — which is exactly what happened when kubernetes_helper#1 merged. A tag is a decision; a default branch is an accident waiting for the next merge.

The URL also names the current organisation. `ReverseRetail` is its former name and git follows the rename redirect, so the old URL worked — but Actions does **not** follow it for a `uses:` reference, and having both names in circulation is what made that hard to see. It is what broke the v1.25.0 release build.

`cd.yml` held an older pipeline — `gem install kubernetes_helper` from rubygems, `ubuntu-latest`, GCR images, no inputs. Nothing references it any more, so it now carries `cd_new.yml`'s contents rather than remaining a second pipeline that quietly diverges. **Before pointing anything at it:** it takes seven required inputs it did not take before — `APP_NAME`, `GAR_BETA_REGION`, `GAR_PROD_REGION`, `GCP_STAGING_PROJECT_ID`, `GCP_PROD_PROJECT_ID`, `GAR_STAGING_REPO`, `GAR_PRODUCTION_REPO`. A reusable workflow called without a required input fails before it starts a single job. `cd_new.yml` is identical and kept only for its existing callers; each header points at the other and says to converge here.

### `4a1a2fd` — dependabot

`github-actions` only; there is no Gemfile or package.json here. Grouped into one weekly PR: these workflows run inside every application's deployment, so a bump here changes how all of them build and deploy on their next run, and that is easier to judge as one change than as several. Nothing is lost by grouping — dependabot bumps every occurrence of an action together anyway.

### `b120905` — the actions

| | from | to |
| --- | --- | --- |
| `actions/checkout` | `v4` (cd), `v2` (other three) | `v7` |
| `actions/upload-artifact` | `v4` and **`master`** | `v7` |
| `styfle/cancel-workflow-action` | `0.6.0` | `0.12.0` |
| `jpribyl/action-docker-layer-caching` | `v0.1.0` | `v0.1.1` |

The checkout and upload-artifact versions are the ones dependabot proposed in kubernetes_helper today — each of those PRs passed CI and that repo's master is green carrying them, on the same runner images. That is what makes this a check rather than a guess. The last two move to versions the deployment workflows in this same repository already run.

`upload-artifact@master` resolves today, so pinning it is determinism rather than a repair: an upstream change to that branch can no longer alter the test workflow of every calling application without a commit here — the same reasoning as pinning the gem.

**Everything else is deliberately untouched.** This session cannot read releases outside its own repository scope, so the current version of the remaining third-party actions isn't something it can establish, and inventing one would be worse than leaving it: an unresolvable `uses:` ends a run instantly with no jobs and no log. The dependabot group will propose those with real numbers. One reference still tracks a branch — `tokorom/action-slack-incoming-webhook@main` — which dependabot won't bump and which needs a version lookup to pin.

### Verification

The pinned install was run for real under **ruby 3.3.6** — the shape of the runner, since that step has no `setup-ruby` and installs under the runner image's system ruby:

```
Successfully built RubyGem  Name: kubernetes_helper  Version: 1.25.0
Successfully installed
```

The tag resolves, the gem builds, its new `ostruct` and `erb` dependencies resolve, and it installs. The `>= 3.2` floor is load-bearing: a 4.0.6 floor fails this step outright.

That installed gem then rendered storage_service's staging manifest, with the application's temporary template override moved aside so the gem's own template is used:

```yaml
image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.25.4
args:
- "--credentials-file=/secrets/gcloud/credentials.json"
- rere-playground:europe-west4:mysql-reverse-retail-staging?port=3306
```

`instance=tcp:3306` from the settings is translated to `instance?port=3306` for the v2 proxy, on the web and job pods both, so no application's `settings.rb` has to change.

### Not in this PR

Applications still point at `cd_new.yml`. Moving them to `cd.yml` and deleting `cd_new.yml` is a follow-up, one caller at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sHdoqpBb5WopxWRLRmYpV