### PR TITLE
Move the pinned kubernetes_helper to v1.26.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,7 +103,7 @@ jobs:
         # whatever the default branch happened to hold at the moment of the deployment, so
         # merging anything into that gem changed every application's next deploy with no
         # release, review or rollback in between. -t takes a git tag.
-        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.25.0
+        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.26.0
 
       # Staging deployment
 

--- a/.github/workflows/cd_new.yml
+++ b/.github/workflows/cd_new.yml
@@ -94,7 +94,7 @@ jobs:
         # whatever the default branch happened to hold at the moment of the deployment, so
         # merging anything into that gem changed every application's next deploy with no
         # release, review or rollback in between. -t takes a git tag.
-        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.25.0
+        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.26.0
 
       # Staging deployment
 


### PR DESCRIPTION
```diff
-        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.25.0
+        run: sudo gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.26.0
```

Both `cd.yml` and `cd_new.yml` pin the gem, so both move together.

## What reaches applications without them asking

**One thing:** an application using `sidekiq_alive_gem` gets a `startupProbe` on its job container in place of a liveness probe with `initialDelaySeconds: 80`.

Worth being explicit that this is more forgiving in **both** directions, not less:

| | before | after |
| --- | --- | --- |
| boots quickly | ready at a fixed 80s | ready as soon as 7433 answers (~5s after boot) |
| boots slowly | killed at `80 + 3×10` = 110s | 36 attempts at 5s = **180s** before giving up |

On storage_service that fixed delay was costing 53 idle seconds per restart against a 27-second boot, and the 110s ceiling is what had been killing the pod mid-boot earlier today. Applications not using `sidekiq_alive_gem` are untouched.

## What is opt-in

Everything else in v1.26.0 defaults to today's behaviour:

- `job_apps[].min_ready_seconds` — default `10`, unchanged
- `deployment.termination_grace_period_seconds` — default `120`, unchanged
- `job_apps` built from the older `job_*` keys now actually carry `rolling_update` and `min_ready_seconds` through, which they silently dropped before — so an application that had set `job_rolling_update` and seen nothing happen will now get what it asked for

That last one is the only case where an existing setting starts taking effect. Worth a glance at any `settings.rb` that sets `job_rolling_update` today.

## Verification

Ran the pinned command itself rather than just reading it:

```
$ gem specific_install -l https://github.com/BuddyandSelly/kubernetes_helper -t v1.26.0
  Successfully built RubyGem
  Name: kubernetes_helper
  Version: 1.26.0
Successfully installed
```

`v1.26.0` is tagged at `1e05389` and its release built successfully — the first one to do so since the organisation rename, now that `release_builder.yml` names the current org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sHdoqpBb5WopxWRLRmYpV

---
_Generated by [Claude Code](https://claude.ai/code/session_019sHdoqpBb5WopxWRLRmYpV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BuddyandSelly/codesmith/reusable-ci-cd-actions/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791055824&installation_model_id=428486&pr_number=4&repository=BuddyandSelly%2Freusable-ci-cd-actions&return_to=https%3A%2F%2Fgithub.com%2FBuddyandSelly%2Freusable-ci-cd-actions%2Fpull%2F4&signature=566c3f6b39ed137e35268dfe3dfe7a09411bcbef4488d847caaf540adf0ab3c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->